### PR TITLE
Add Android ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ build/
 
 # FVM Version Cache
 .fvm/
+/example/android/app/.cxx

--- a/android/src/main/kotlin/com/flutter/flutter_core/FlutterCorePlugin.kt
+++ b/android/src/main/kotlin/com/flutter/flutter_core/FlutterCorePlugin.kt
@@ -3,12 +3,16 @@ package com.flutter.flutter_core
 import androidx.annotation.NonNull
 import com.huawei.hms.api.HuaweiApiAvailability
 import android.content.Context
+import android.annotation.SuppressLint
+import android.content.ContentResolver
+import android.provider.Settings
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+
 
 /** FlutterCorePlugin */
 class FlutterCorePlugin: FlutterPlugin, MethodCallHandler {
@@ -18,8 +22,10 @@ class FlutterCorePlugin: FlutterPlugin, MethodCallHandler {
   /// This local reference serves to register the plugin with the Flutter Engine and unregister it
   /// when the Flutter Engine is detached from the Activity
   private lateinit var channel : MethodChannel
+  private lateinit var contentResolver: ContentResolver
 
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
+    contentResolver = flutterPluginBinding.applicationContext.contentResolver
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_core")
     channel.setMethodCallHandler(this)
     mContext = flutterPluginBinding.applicationContext
@@ -34,15 +40,27 @@ class FlutterCorePlugin: FlutterPlugin, MethodCallHandler {
       val sdkVersion = android.os.Build.VERSION.SDK_INT
       val availability = HuaweiApiAvailability.getInstance().isHuaweiMobileServicesAvailable(mContext!!,sdkVersion)
       result.success(availability)
+    }else if (call.method == "getAndroidId") {
+      try {
+        result.success(getAndroidId())
+      } catch (e: Exception) {
+        result.error("ERROR_GETTING_ID", "Failed to get Android ID", e.localizedMessage)
+      }
     }
     else {
       result.notImplemented()
     }
   }
 
+  @SuppressLint("HardwareIds")
+  private fun getAndroidId(): String? {
+    return Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID)
+  }
+
   override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
     mContext = null
   }
+
 
 }

--- a/example/android/.gitignore
+++ b/example/android/.gitignore
@@ -11,3 +11,4 @@ GeneratedPluginRegistrant.java
 key.properties
 **/*.keystore
 **/*.jks
+/example/android/app/.cxx

--- a/lib/src/utils/device_info/device_info_impl.dart
+++ b/lib/src/utils/device_info/device_info_impl.dart
@@ -10,6 +10,7 @@ abstract interface class ICoreDeviceInfo {
   Future<CoreIosDeviceInfo> get iosInfo;
 
   Future<String?> get deviceName;
+  Future<String?> get deviceIdentifier;
 }
 
 class CoreDeviceInfo implements ICoreDeviceInfo {
@@ -55,18 +56,23 @@ class CoreDeviceInfo implements ICoreDeviceInfo {
   }
 
   @override
+  @Deprecated('Use deviceIdentifier instead')
   Future<String?> get deviceName async {
-    return Platform.isIOS ? _getIosDeviceName : _getAndroidDeviceName;
+    return Platform.isIOS ? _getIosDeviceIdentifier : _getAndroidDeviceIdentifier;
   }
 
-  Future<String?> get _getIosDeviceName async {
+  @override
+  Future<String?> get deviceIdentifier async {
+    return Platform.isIOS ? _getIosDeviceIdentifier : _getAndroidDeviceIdentifier;
+  }
+
+  Future<String?> get _getIosDeviceIdentifier async {
     final iosInfo = await _deviceInfoPlugin.iosInfo;
-    return iosInfo.identifierForVendor ?? iosInfo.localizedModel;
+    return iosInfo.identifierForVendor;
   }
 
-  Future<String?> get _getAndroidDeviceName async {
-    // TODO(Huseyin): Hüseyinin yaptığı android id kütüphanesi eklenecek.
-    return null;
+  Future<String?> get _getAndroidDeviceIdentifier async {
+    return CorePlatformChannel.getAndroidDeviceId();
   }
 
   Future<bool> isHuaweiApiAvailable() {

--- a/lib/src/utils/platform_channel/platform_channel_impl.dart
+++ b/lib/src/utils/platform_channel/platform_channel_impl.dart
@@ -8,4 +8,6 @@ abstract class CorePlatformChannel {
   static Future<bool> isHuaweiApiAvailable() async {
     return (await _channel.invokeMethod('getHuaweiApiAvailability')) == 0;
   }
+
+  static Future<String?> getAndroidDeviceId() async => _channel.invokeMethod('getAndroidId');
 }


### PR DESCRIPTION
Add Android ID retrieval and update device info interface  - Implement `getAndroidId` method in `FlutterCorePlugin` to retrieve the Android ID. - Update `ICoreDeviceInfo` interface to include `deviceIdentifier`. - Refactor `CoreDeviceInfo` to use `deviceIdentifier` instead of `deviceName`. - Add `.cxx` directory to `.gitignore` files in both root and example Android directories.