### PR TITLE
Add string formatting extensions and update phone number text field  …

### DIFF
--- a/lib/src/common/extensions/string_extensions/string_extensions.dart
+++ b/lib/src/common/extensions/string_extensions/string_extensions.dart
@@ -18,4 +18,16 @@ extension StringExtensionNullable on String? {
 
   /// Truncates the string to the given length
   String? truncateToLength({int length = 25, String suffix = '...'}) => this != null && this!.length > length ? '${this!.substring(0, length)}$suffix' : this;
+
+  /// To capitalized string => hello world => Hello world
+  String? toCapitalized() {
+    if (isNullOrEmpty) return null;
+    return '${this![0].toUpperCase()}${this!.substring(1).toLowerCase()}';
+  }
+
+  /// To title case string => hello world => Hello World
+  String? toTitleCase() {
+    if (isNullOrEmpty) return null;
+    return this?.replaceAll(RegExp(' +'), ' ').split(' ').map((str) => str.toCapitalized() ?? '').join(' ');
+  }
 }

--- a/lib/src/utils/input_formatter/input_formatter_impl.dart
+++ b/lib/src/utils/input_formatter/input_formatter_impl.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/services.dart';
+import 'package:flutter_core/flutter_core.dart';
 
 enum MaskAutoCompletionType {
   lazy,
@@ -383,6 +384,28 @@ class LowerCaseFormatter extends TextInputFormatter {
   TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
     return TextEditingValue(
       text: newValue.text.toLowerCase(),
+      selection: newValue.selection,
+    );
+  }
+}
+
+/// Convert first letter of each word to uppercase
+class UpperCaseFirstLetterFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    return TextEditingValue(
+      text: newValue.text.toCapitalized() ?? '',
+      selection: newValue.selection,
+    );
+  }
+}
+
+/// Title case formatter
+class TitleCaseFormatter extends TextInputFormatter {
+  @override
+  TextEditingValue formatEditUpdate(TextEditingValue oldValue, TextEditingValue newValue) {
+    return TextEditingValue(
+      text: newValue.text.toTitleCase() ?? '',
       selection: newValue.selection,
     );
   }

--- a/lib/src/utils/input_formatter/input_formatters.dart
+++ b/lib/src/utils/input_formatter/input_formatters.dart
@@ -45,6 +45,12 @@ abstract class CoreDefaultInputFormatter {
   /// Lower Case formatter
   static TextInputFormatter lowerCase() => LowerCaseFormatter();
 
+  /// Upper Case first letter formatter
+  static TextInputFormatter upperCaseFirstLetter() => UpperCaseFirstLetterFormatter();
+
+  /// Title case formatter
+  static TextInputFormatter titleCase() => TitleCaseFormatter();
+
   /// Upper Case formatter
   static TextInputFormatter upperCase() => UpperCaseFormatter();
 

--- a/lib/src/widgets/text_field/phone_number_text_field_impl.dart
+++ b/lib/src/widgets/text_field/phone_number_text_field_impl.dart
@@ -48,7 +48,7 @@ enum PhoneNumberFormat {
       PhoneNumberFormat.prefixWithCountryParens => '##) ### ## ##',
       PhoneNumberFormat.prefixWithCountry => '## ### ## ##',
       PhoneNumberFormat.prefixWithZeroParens => '##) ### ## ##',
-      PhoneNumberFormat.prefixWithZero => '## ### ## ##',
+      PhoneNumberFormat.prefixWithZero => '(###) ### ## ##',
     };
   }
 
@@ -86,6 +86,7 @@ class CorePhoneNumberTextField extends StatelessWidget {
     this.countryCode = _trCountryCode,
     this.carrierPrefix = _trCarrierPrefix,
     this.floatingLabelBehavior = FloatingLabelBehavior.always,
+    this.enableInteractiveSelection = false,
     super.key,
   });
 
@@ -109,10 +110,12 @@ class CorePhoneNumberTextField extends StatelessWidget {
   final String countryCode;
   final String carrierPrefix;
   final FloatingLabelBehavior floatingLabelBehavior;
+  final bool enableInteractiveSelection;
 
   @override
   Widget build(BuildContext context) {
     return TextFormField(
+      enableInteractiveSelection: enableInteractiveSelection,
       controller: controller,
       enabled: enabled,
       focusNode: focusNode,


### PR DESCRIPTION
…- Implement `toCapitalized` and `toTitleCase` methods in StringExtensionNullable for string formatting. - Introduce UpperCaseFirstLetterFormatter and TitleCaseFormatter for text input formatting. - Update CoreDefaultInputFormatter to include new formatters. - Modify CorePhoneNumberTextField to add enableInteractiveSelection property and adjust phone number format.

Add string formatting extensions and update phone number text field

- Implement `toCapitalized` and `toTitleCase` methods in StringExtensionNullable for string formatting.
- Introduce UpperCaseFirstLetterFormatter and TitleCaseFormatter for text input formatting.
- Update CoreDefaultInputFormatter to include new formatters.
- Modify CorePhoneNumberTextField to add enableInteractiveSelection property and adjust phone number format.